### PR TITLE
Fix message duplication and improve chat room handling

### DIFF
--- a/server.py
+++ b/server.py
@@ -129,5 +129,14 @@ def get_new_messages():
     else:
         return jsonify([]), 200
 
+
+
+@app.route('/get_all_messages', methods=['GET'])
+def get_all_messages():
+    room_name = request.args.get('room_name')
+    if room_name in messages:
+        return jsonify(messages[room_name]), 200
+    return jsonify([]), 200
+
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
# Message Duplication Fix and Chat Improvements

## Problem
Users experienced message duplication when clicking on chat rooms multiple times. This was caused by:
1. Redundant message loading from both local storage and server

## Solution
This PR implements a comprehensive fix for message handling:

### Client Changes
- Prevent unnecessary room reloading
- Use server as single source of truth for messages


### Server Changes
- Add new endpoint `/get_all_messages` for complete history

## Testing Done
- Manually verified no message duplication occurs
- Tested room switching with various message loads
- Verified backward compatibility with existing features


Please review the code thoroughly for any potential issues or improvements, as I'm still learning and appreciate any feedback